### PR TITLE
add option to set wasm path with env variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,12 +11,13 @@ import type { File, ShOptions, ShPrintOptions } from './types.js'
 const importMetaUrl = import.meta.url
 
 /* istanbul ignore next -- @preserve */
+const wasmfile = process.env.SH_SYNTAX_WASM_PATH
 const _dirname = importMetaUrl
   ? path.dirname(fileURLToPath(importMetaUrl))
   : __dirname
 
 export const processor = getProcessor(() =>
-  fs.readFile(path.resolve(_dirname, '../main.wasm')),
+  fs.readFile(wasmfile === undefined ? path.resolve(_dirname, '../main.wasm') : path.resolve(wasmfile)),
 )
 
 export const parse = (text: string, options?: ShOptions) =>


### PR DESCRIPTION
I want this option to set a custom path to the file instead of this hardcoded one which doesn't work for me.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for `SH_SYNTAX_WASM_PATH` environment variable to set a custom WASM file path in `src/index.ts`.
> 
>   - **Behavior**:
>     - Adds support for `SH_SYNTAX_WASM_PATH` environment variable in `src/index.ts` to set a custom path for the WASM file.
>     - `processor` function now reads the WASM file from the path specified by `SH_SYNTAX_WASM_PATH`, if defined, otherwise defaults to `../main.wasm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fsh-syntax&utm_source=github&utm_medium=referral)<sup> for 946ac330df9e147342e4a3b17d55d468546890f7. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for overriding the WebAssembly file location via the SH_SYNTAX_WASM_PATH environment variable.
  * When set, the app loads the WASM binary from the provided path; otherwise, it uses the default bundled path.
  * No changes to public APIs or behavior beyond configuration.
  * Improves deployment flexibility by enabling custom WASM placement without code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->